### PR TITLE
Added Client Sample ID in the exporter output

### DIFF
--- a/bhp/lims/export.py
+++ b/bhp/lims/export.py
@@ -62,6 +62,7 @@ def to_wf_state(obj, key, value):
 SAMPLES_ROWS = [
     # TITLE, ATTRIBUTE, CONVERTER FUNCTION
     (u"Sample-ID", "getId", to_string),
+    (u"Client-Sample-ID", "getClientSampleID", to_string),
     (u"Client-ID", "Client.ClientID", to_string),
     (u"Client Name", "getClientTitle", to_string),
     (u"Contact", "getContactFullName", to_string),
@@ -87,6 +88,7 @@ SAMPLES_ROWS = [
 ANALYSES_ROWS = [
     # TITLE, ATTRIBUTE, CONVERTER FUNCTION
     (u"Sample-ID", "getId", to_string),
+    (u"Client-Sample-ID", "getClientSampleID", to_string),
     (u"Client-ID", "Client.ClientID", to_string),
     (u"Client Name", "getClientTitle", to_string),
     (u"Contact", "getContactFullName", to_string),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/bhp-lims/bhp.lims/issues/229 (partial)

## Current behavior before PR

Client Sample ID column does not appear in CSV output

## Desired behavior after PR is merged

Client Sample ID column does appear in CSV output

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
