### PR TITLE
Allow to dettach partitions from its Primary

### DIFF
--- a/bhp/lims/browser/configure.zcml
+++ b/bhp/lims/browser/configure.zcml
@@ -137,6 +137,18 @@
     layer="bhp.lims.interfaces.IBhpLIMS" />
 
   <!--
+  Dettached Partition viewlet
+  -->
+  <browser:viewlet
+    for="bika.lims.interfaces.IAnalysisRequest"
+    name="bhp.lims.dettached_partition_viewlet"
+    class=".viewlets.DettachedPartitionViewlet"
+    manager="plone.app.layout.viewlets.interfaces.IAboveContent"
+    template="templates/dettached_partition_viewlet.pt"
+    permission="zope2.View"
+    layer="bhp.lims.interfaces.IBhpLIMS" />
+
+  <!--
   Panic Level Alert Email view
   -->
   <browser:page

--- a/bhp/lims/browser/templates/dettached_partition_viewlet.pt
+++ b/bhp/lims/browser/templates/dettached_partition_viewlet.pt
@@ -1,0 +1,21 @@
+<div tal:omit-tag=""
+     tal:define="primary python: view.get_dettached_from()"
+     tal:condition="python: primary"
+     i18n:domain="bhp.lims">
+
+  <div class="visualClear"></div>
+
+  <div id="portal-alert">
+    <div class="portlet-alert-item alert alert-info alert-dismissible">
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <strong i18n:translate="">Info</strong>
+      <p class="title">
+        <span i18n:translate="">This is a Dettached partition from Sample </span>
+        <a tal:attributes="href python:primary.absolute_url()"
+           tal:content="python:primary.getId()"></a>
+      </p>
+    </div>
+  </div>
+</div>

--- a/bhp/lims/browser/viewlets.py
+++ b/bhp/lims/browser/viewlets.py
@@ -39,3 +39,22 @@ class PanicAlertViewlet(ViewletBase):
                                             default=False)
         self.ar_uid = api.get_uid(self.context)
         return self.template()
+
+
+class DettachedPartitionViewlet(ViewletBase):
+    """Prints a viewlet that displays the Primary Sample the sample was
+    dettached from
+    """
+    template = ViewPageTemplateFile("templates/dettached_partition_viewlet.pt")
+
+    def __init__(self, context, request, view, manager=None):
+        super(DettachedPartitionViewlet, self).__init__(
+            context, request, view, manager=manager)
+
+    def get_dettached_from(self):
+        """Returns the sample the partition was dettached from
+        """
+        return api.get_field_value(self.context, "DettachedFrom", None)
+
+    def render(self):
+        return self.template()

--- a/bhp/lims/content/analysisrequest.py
+++ b/bhp/lims/content/analysisrequest.py
@@ -272,6 +272,18 @@ fields = [
             showOn=False,
         ),
     ),
+    ExtReferenceField(
+        "DettachedFrom",
+        required=0,
+        allowed_types=("AnalysisRequest",),
+        relationship="AnalysisRequestDettachedFrom",
+        mode="rw",
+        read_permission=View,
+        write_permission=ModifyPortalContent,
+        widget=ReferenceWidget(
+            visible=False,
+        )
+    ),
     ExtBooleanField(
         "PanicEmailAlertSent",
         default=False,

--- a/bhp/lims/setuphandlers.py
+++ b/bhp/lims/setuphandlers.py
@@ -166,7 +166,7 @@ WORKFLOWS_TO_UPDATE = {
             "sample_at_reception": {
                 "title": "At reception",
                 "description": "Sample at reception",
-                "transitions": ("send_to_pot", "process", "reject", "store"),
+                "transitions": ("send_to_pot", "process", "reject", "dettach", "store",),
                 "permissions_copy_from": "sample_due",
             },
 
@@ -174,6 +174,7 @@ WORKFLOWS_TO_UPDATE = {
             "sample_due": {
                 "title": "Sent to point of testing",
                 "description": "Sample sent to point of testing",
+                "transitions": ("dettach", "store"),
                 "preserve_transitions": True,
             },
 
@@ -181,8 +182,28 @@ WORKFLOWS_TO_UPDATE = {
             "sample_received": {
                 "title": "At point of testing",
                 "description": "Sample at point of testing",
+                "transitions": ("dettach",),
                 "preserve_transitions": True,
             },
+
+            # To be verified
+            "to_be_verified": {
+                "transitions": ("dettach",),
+                "preserve_transitions": True,
+            },
+
+            # Verified
+            "verified": {
+                "transitions": ("dettach",),
+                "preserve_transitions": True,
+            },
+
+            # Stored
+            "stored": {
+                "transitions": ("dettach",),
+                "preserve_transitions": True,
+            }
+
         },
         "transitions": {
             # Clinic submits the sample (Add form)
@@ -245,6 +266,16 @@ WORKFLOWS_TO_UPDATE = {
                 }
             },
 
+            # Dettach a partition from it's parent sample
+            "dettach": {
+                "title": "Dettach partition",
+                "new_state": "",
+                "guard": {
+                    "guard_permissions": "",
+                    "guard_roles": "",
+                    "guard_expr": "python:here.guard_dettach()"
+                }
+            }
         }
     }
 }
@@ -258,7 +289,8 @@ ROLE_MAPPINGS = [
               "sample_shipped",
               "sample_at_reception",
               "sample_due",
-              "sample_received"]),
+              "sample_received",
+              "stored"]),
      CATALOG_ANALYSIS_REQUEST_LISTING)
 ]
 

--- a/bhp/lims/skins/bhp_scripts/guard_dettach.py
+++ b/bhp/lims/skins/bhp_scripts/guard_dettach.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018-2019 Botswana Harvard Partnership (BHP)
+
+## Script (Python) "guard_dettach"
+##bind container=container
+##bind context=context
+##bind namespace=
+##bind script=script
+##bind subpath=traverse_subpath
+##parameters=
+##title=
+##
+
+from bhp.lims.workflow.analysisrequest.guards import guard_dettach
+return guard_dettach(context)

--- a/bhp/lims/workflow/analysisrequest/events.py
+++ b/bhp/lims/workflow/analysisrequest/events.py
@@ -46,9 +46,7 @@ def after_deliver(analysis_request):
 def after_send_to_pot(analysis_request):
     """Event fired after sending to point of testing
     """
-    # Other partitions should not follow the partition that is sent to testing
-    # https://github.com/bhp-lims/bhp.lims/issues/246
-    #events.do_action_to_ancestors(analysis_request, "send_to_pot")
+    events.do_action_to_ancestors(analysis_request, "send_to_pot")
     events.do_action_to_descendants(analysis_request, "send_to_pot")
 
 
@@ -66,3 +64,12 @@ def after_receive(analysis_request):
 
     events.do_action_to_ancestors(analysis_request, "receive")
     events.do_action_to_descendants(analysis_request, "receive")
+
+
+def after_dettach(analysis_request):
+    """Method triggered after "dettach" transition for the Analysis Request
+    passed in is performed
+    """
+    parent = analysis_request.getParentAnalysisRequest()
+    analysis_request.setParentAnalysisRequest(None)
+    api.set_field_value(analysis_request, "DettachedFrom", parent)

--- a/bhp/lims/workflow/analysisrequest/guards.py
+++ b/bhp/lims/workflow/analysisrequest/guards.py
@@ -75,3 +75,15 @@ def guard_receive_at_pot(analysis_request):
 
     # Do not allow if the current user is a Client contact
     return not api.is_client_contact()
+
+
+@security.public
+def guard_dettach(analysis_request):
+    """Guard dettach partition
+    """
+    # Dettach transition can only be done to partitions
+    if not analysis_request.isPartition():
+        return False
+    # If the current user is a Client contact, do not allow to dettach
+    return not api.is_client_contact()
+


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Requests adds an additional transition "dettach", only available for Partitions. This transition makes the partition to be dettached from the primary, so is no longer a "real-partition". Nevertheless, the system keeps track of that relationship and displays a message informing the user about that ancestry.

Primary samples always follows the statuses of its partitions. With this enhancement, the user can overcome this caveat in some particular cases (e.g. when one of the partitions is stored or when one of the partitions is for internal use only - thus, it does not make sense for this partition to reach the "published" status).

This Pull request is meant to solve several issues related with the fact that primary always follows its children:

https://github.com/bhp-lims/bhp.lims/issues/246
https://github.com/bhp-lims/bhp.lims/issues/245


## Current behavior before PR

Cannot dettach a partition from its primary sample

## Desired behavior after PR is merged

Can dettach a partition from its primary sample. Therefore, the primary sample is no longer bound to the status of the dettached partition and can follow the status from the rest of partitions.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
